### PR TITLE
Add orgs

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func buildRoutes(th *tme.Handler) {
 
 	http.HandleFunc(status.BuildInfoPath, status.BuildInfoHandler)
 
-	var checks = []fthealth.Check{th.HealthCheck()}
+	var checks = th.HealthCheck()
 
 	timedHC := fthealth.TimedHealthCheck{
 		HealthCheck: fthealth.HealthCheck{

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 	app.Run(os.Args)
 }
 
-var spareWorkers int = 10
+var spareWorkers = 10
 
 func getResilientClient(writerWorkers int) *pester.Client {
 	c := &http.Client{

--- a/tme/middleware.go
+++ b/tme/middleware.go
@@ -9,7 +9,10 @@ import (
 
 func (th *Handler) EnforceDataLoaded(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !th.service.IsDataLoaded() {
+		vars := mux.Vars(r)
+		endpoint := vars[endpointURLParameter]
+
+		if !th.service.IsDataLoaded(endpoint) {
 			w.Header().Set("Content-Type", "application/json")
 			writeJSONMessageWithStatus(w, "Data not loaded", http.StatusServiceUnavailable)
 			return

--- a/tme/middleware_test.go
+++ b/tme/middleware_test.go
@@ -13,32 +13,32 @@ func TestHandler_Middleware(t *testing.T) {
 	data := []struct {
 		name       string
 		url        string
-		isLoaded   bool
+		loadingStatus    map[string]bool
 		resultCode int
 	}{
 		{
 			"Success",
 			"/transformers/genres/__count",
-			true,
+			map[string]bool{"genres": true},
 			200,
 		},
 		{
 			"Fail - No data loaded",
 			"/transformers/genres/__count",
-			false,
+			map[string]bool{"genres": false},
 			503,
 		},
 		{
 			"Fail - Taxonomy incorrect",
 			"/transformers/fake/__count",
-			true,
+			map[string]bool{"fake": true},
 			400,
 		},
 	}
 
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
-			mockService := NewMockService(d.isLoaded, nil, nil)
+			mockService := NewMockService(nil, nil, d.loadingStatus)
 			handler := NewHandler(mockService)
 
 			req, _ := http.NewRequest("GET", d.url, nil)

--- a/tme/service_test.go
+++ b/tme/service_test.go
@@ -92,7 +92,7 @@ func TestInit(t *testing.T) {
 	defer func() {
 		repo.Done()
 	}()
-	assert.False(t, service.IsDataLoaded())
+	assert.False(t, service.IsDataLoaded("topics"))
 }
 
 func createTestTmeService(repos map[string]tmereader.Repository, cacheFileName string, httpClient httpClient) Service {

--- a/tme/transformer.go
+++ b/tme/transformer.go
@@ -126,4 +126,9 @@ var EndpointTypeMappings = map[string]map[string]interface{}{
 		"source":   &tmereader.KnowledgeBases{},
 		"type":     "Topic",
 	},
+	"organisations": {
+		"taxonomy": "ON",
+		"source":   &tmereader.AuthorityFiles{},
+		"type":     "Organisation",
+	},
 }


### PR DESCRIPTION
- Support the ingestion of organisations
- Change the gtg logic (now 200 when at least one dataset is loaded) - fixes https://github.com/Financial-Times/basic-tme-transformer/issues/11
- Endpoints are only blocked when the dataset related to them is loading, not when any dataset is loading.